### PR TITLE
Bump org.jetbrains.kotlin.jvm from 1.4.21 to 1.4.21-2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.4.21"
+    id("org.jetbrains.kotlin.jvm") version "1.4.21-2"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "0.6.5"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin


### PR DESCRIPTION
Bumps org.jetbrains.kotlin.jvm from 1.4.21 to 1.4.21-2.

Signed-off-by: dependabot[bot] <support@github.com>