### PR TITLE
Using new reusable settings' UI components

### DIFF
--- a/src/main/kotlin/org/jetbrains/tinygoplugin/configuration/TinyGoConfiguration.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/configuration/TinyGoConfiguration.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 
 data class TinyGoConfiguration(
-    private val project: Project,
+    private val project: Project?,
     private val userConfig: UserConfigurationState = UserConfigurationState(),
     private val projectConfig: ProjectConfigurationState = ProjectConfigurationState(),
 ) : UserConfiguration by userConfig, ProjectConfiguration by projectConfig {

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoNewProjectSettings.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoNewProjectSettings.kt
@@ -2,10 +2,20 @@ package org.jetbrains.tinygoplugin.project.wizard
 
 import com.goide.sdk.GoSdk
 import com.goide.wizard.GoNewProjectSettings
-import org.jetbrains.annotations.NotNull
+import org.jetbrains.tinygoplugin.configuration.GarbageCollector
+import org.jetbrains.tinygoplugin.configuration.Scheduler
+
+interface TinyGoInfoArguments {
+    var tinyGoSdkPath: String
+    var tinyGoTarget: String
+    var tinyGoGarbageCollector: GarbageCollector
+    var tinyGoScheduler: Scheduler
+}
 
 data class TinyGoNewProjectSettings(
-    var sdk: @NotNull GoSdk,
-    var tinyGoSdkPath: String,
-    var tinyGoTarget: String
-) : GoNewProjectSettings(sdk)
+    var sdk: GoSdk,
+    override var tinyGoSdkPath: String,
+    override var tinyGoTarget: String,
+    override var tinyGoGarbageCollector: GarbageCollector,
+    override var tinyGoScheduler: Scheduler,
+) : GoNewProjectSettings(sdk), TinyGoInfoArguments

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoNewProjectSettings.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoNewProjectSettings.kt
@@ -2,20 +2,9 @@ package org.jetbrains.tinygoplugin.project.wizard
 
 import com.goide.sdk.GoSdk
 import com.goide.wizard.GoNewProjectSettings
-import org.jetbrains.tinygoplugin.configuration.GarbageCollector
-import org.jetbrains.tinygoplugin.configuration.Scheduler
-
-interface TinyGoInfoArguments {
-    var tinyGoSdkPath: String
-    var tinyGoTarget: String
-    var tinyGoGarbageCollector: GarbageCollector
-    var tinyGoScheduler: Scheduler
-}
+import org.jetbrains.tinygoplugin.configuration.TinyGoConfiguration
 
 data class TinyGoNewProjectSettings(
     var sdk: GoSdk,
-    override var tinyGoSdkPath: String,
-    override var tinyGoTarget: String,
-    override var tinyGoGarbageCollector: GarbageCollector,
-    override var tinyGoScheduler: Scheduler,
-) : GoNewProjectSettings(sdk), TinyGoInfoArguments
+    var tinyGoSettings: TinyGoConfiguration
+) : GoNewProjectSettings(sdk)

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGenerator.kt
@@ -30,14 +30,6 @@ class TinyGoProjectGenerator : GoProjectGenerator<TinyGoNewProjectSettings>() {
             tinyGoSettings.extractTinyGoInfo(output)
             tinyGoSettings.saveState(project)
         }
-
-        /*val executor = infoExtractor.assembleTinyGoShellCommand(tinyGoSettings)
-
-        executor.executeWithProgress(true, true, processHistory, null) { result ->
-            val output = processHistory.output.joinToString("")
-            tinyGoSettings.extractTinyGoInfo(output)
-            tinyGoSettings.saveState(project)
-        }*/
     }
 
     override fun doGenerateProject(
@@ -46,14 +38,8 @@ class TinyGoProjectGenerator : GoProjectGenerator<TinyGoNewProjectSettings>() {
         newProjectSettings: TinyGoNewProjectSettings,
         module: Module
     ) {
-        val tinyGoSettings = TinyGoConfiguration.getInstance(project)
-        tinyGoSettings.tinyGoSDKPath = newProjectSettings.tinyGoSdkPath
-        tinyGoSettings.targetPlatform = newProjectSettings.tinyGoTarget
-        tinyGoSettings.gc = newProjectSettings.tinyGoGarbageCollector
-        tinyGoSettings.scheduler = newProjectSettings.tinyGoScheduler
-        tinyGoSettings.saveState(project)
-
-        extractTinyGoSettings(project, tinyGoSettings)
+        newProjectSettings.tinyGoSettings.saveState(project)
+        extractTinyGoSettings(project, newProjectSettings.tinyGoSettings)
 
         TinyGoSdkUtil.notifyTinyGoNotConfigured(
             project,

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGenerator.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.tinygoplugin.project.wizard
 
 import com.goide.GoIcons
+import com.goide.util.GoHistoryProcessListener
 import com.goide.wizard.GoProjectGenerator
 import com.intellij.facet.ui.ValidationResult
 import com.intellij.openapi.module.Module
@@ -9,6 +10,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.ProjectGeneratorPeer
 import org.jetbrains.tinygoplugin.configuration.TinyGoConfiguration
 import org.jetbrains.tinygoplugin.sdk.TinyGoSdkUtil
+import org.jetbrains.tinygoplugin.services.TinyGoInfoExtractor
+import org.jetbrains.tinygoplugin.services.extractTinyGoInfo
 import javax.swing.Icon
 
 class TinyGoProjectGenerator : GoProjectGenerator<TinyGoNewProjectSettings>() {
@@ -20,6 +23,23 @@ class TinyGoProjectGenerator : GoProjectGenerator<TinyGoNewProjectSettings>() {
 
     override fun validate(baseDirPath: String): ValidationResult = ValidationResult.OK
 
+    private fun extractTinyGoSettings(project: Project, tinyGoSettings: TinyGoConfiguration) {
+        val processHistory = GoHistoryProcessListener()
+        TinyGoInfoExtractor(project).extractTinyGoInfo(tinyGoSettings, processHistory) {
+            val output = processHistory.output.joinToString("")
+            tinyGoSettings.extractTinyGoInfo(output)
+            tinyGoSettings.saveState(project)
+        }
+
+        /*val executor = infoExtractor.assembleTinyGoShellCommand(tinyGoSettings)
+
+        executor.executeWithProgress(true, true, processHistory, null) { result ->
+            val output = processHistory.output.joinToString("")
+            tinyGoSettings.extractTinyGoInfo(output)
+            tinyGoSettings.saveState(project)
+        }*/
+    }
+
     override fun doGenerateProject(
         project: Project,
         baseDir: VirtualFile,
@@ -29,7 +49,11 @@ class TinyGoProjectGenerator : GoProjectGenerator<TinyGoNewProjectSettings>() {
         val tinyGoSettings = TinyGoConfiguration.getInstance(project)
         tinyGoSettings.tinyGoSDKPath = newProjectSettings.tinyGoSdkPath
         tinyGoSettings.targetPlatform = newProjectSettings.tinyGoTarget
+        tinyGoSettings.gc = newProjectSettings.tinyGoGarbageCollector
+        tinyGoSettings.scheduler = newProjectSettings.tinyGoScheduler
         tinyGoSettings.saveState(project)
+
+        extractTinyGoSettings(project, tinyGoSettings)
 
         TinyGoSdkUtil.notifyTinyGoNotConfigured(
             project,

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGeneratorPeer.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGeneratorPeer.kt
@@ -3,38 +3,22 @@ package org.jetbrains.tinygoplugin.project.wizard
 import com.goide.sdk.combobox.GoSdkChooserCombo
 import com.goide.wizard.GoProjectGeneratorPeer
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.observable.properties.GraphProperty
-import com.intellij.openapi.observable.properties.GraphPropertyImpl.Companion.graphProperty
-import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.LabeledComponent
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.util.ui.UI.PanelFactory
-import org.jetbrains.tinygoplugin.configuration.GarbageCollector
-import org.jetbrains.tinygoplugin.configuration.Scheduler
+import org.jetbrains.tinygoplugin.configuration.TinyGoConfiguration
 import org.jetbrains.tinygoplugin.sdk.TinyGoSdkUtil
+import org.jetbrains.tinygoplugin.ui.SettingsDependentUI
+import org.jetbrains.tinygoplugin.ui.TinyGoPropertiesWrapper
 import org.jetbrains.tinygoplugin.ui.TinyGoUIComponents
 import javax.swing.BoxLayout
 import javax.swing.JPanel
 
-class TinyGoProjectGeneratorPeer : GoProjectGeneratorPeer<TinyGoNewProjectSettings>() {
-    object TinyGoInfoArgumentsImpl : TinyGoInfoArguments {
-        override var tinyGoSdkPath: String = TinyGoSdkUtil.suggestSdkDirectoryStr()
-        override var tinyGoTarget: String = ""
-        override var tinyGoGarbageCollector: GarbageCollector = GarbageCollector.AUTO_DETECT
-        override var tinyGoScheduler: Scheduler = Scheduler.AUTO_DETECT
-    }
-
-    private val propertyGraph = PropertyGraph()
-    var tinyGoSdkPathProp: GraphProperty<String> =
-        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoSdkPath)
-    private var targetProp: GraphProperty<String> =
-        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoTarget)
-    private var gcProp: GraphProperty<GarbageCollector> =
-        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoGarbageCollector)
-    private var schedulerProp: GraphProperty<Scheduler> =
-        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoScheduler)
+class TinyGoProjectGeneratorPeer : GoProjectGeneratorPeer<TinyGoNewProjectSettings>(), SettingsDependentUI {
+    override var settings: TinyGoConfiguration = TinyGoConfiguration(null)
+    private val propertiesWrapper = TinyGoPropertiesWrapper(this)
 
     private fun decorateSettingsPanelForUI(component: JPanel): JPanel =
         PanelFactory.grid().add(PanelFactory.panel(component)).resize().createPanel()
@@ -51,30 +35,19 @@ class TinyGoProjectGeneratorPeer : GoProjectGeneratorPeer<TinyGoNewProjectSettin
         panel.add(
             decorateSettingsPanelForUI(
                 TinyGoUIComponents.generateTinyGoParametersPanel(
-                    tinyGoSdkPathProp,
-                    {
+                    propertiesWrapper,
+                    fileChosen = {
                         if (TinyGoSdkUtil.checkDirectoryForTinyGo(it)) it.canonicalPath!!
                         else {
                             Messages.showErrorDialog("Selected TinyGo path is invalid", "Invalid TinyGo")
                             TinyGoSdkUtil.suggestSdkDirectoryStr()
                         }
                     },
-                    targetProp,
-                    gcProp,
-                    schedulerProp,
                 )
             )
         )
         return panel
     }
 
-    override fun getSettings(): TinyGoNewProjectSettings {
-        return TinyGoNewProjectSettings(
-            sdk = sdkFromCombo,
-            tinyGoSdkPath = tinyGoSdkPathProp.get(),
-            tinyGoTarget = targetProp.get(),
-            tinyGoGarbageCollector = gcProp.get(),
-            tinyGoScheduler = schedulerProp.get()
-        )
-    }
+    override fun getSettings(): TinyGoNewProjectSettings = TinyGoNewProjectSettings(sdkFromCombo, settings)
 }

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGeneratorPeer.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/project/wizard/TinyGoProjectGeneratorPeer.kt
@@ -3,47 +3,78 @@ package org.jetbrains.tinygoplugin.project.wizard
 import com.goide.sdk.combobox.GoSdkChooserCombo
 import com.goide.wizard.GoProjectGeneratorPeer
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.observable.properties.GraphProperty
+import com.intellij.openapi.observable.properties.GraphPropertyImpl.Companion.graphProperty
+import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.LabeledComponent
-import com.intellij.openapi.ui.TextFieldWithBrowseButton
-import org.jetbrains.tinygoplugin.sdk.TinyGoSdkUtil
-import javax.swing.JPanel
 import com.intellij.openapi.ui.Messages
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.ui.components.JBTextField
-import com.intellij.ui.components.textFieldWithBrowseButton
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.util.ui.UI.PanelFactory
+import org.jetbrains.tinygoplugin.configuration.GarbageCollector
+import org.jetbrains.tinygoplugin.configuration.Scheduler
+import org.jetbrains.tinygoplugin.sdk.TinyGoSdkUtil
+import org.jetbrains.tinygoplugin.ui.TinyGoUIComponents
+import javax.swing.BoxLayout
+import javax.swing.JPanel
 
 class TinyGoProjectGeneratorPeer : GoProjectGeneratorPeer<TinyGoNewProjectSettings>() {
-    private val tinyGoSdkBrowser = textFieldWithBrowseButton(
-        null, "Choose TinyGo SDK Home",
-        FileChooserDescriptorFactory.createSingleFolderDescriptor(),
-        fileChosen = {
-            if (TinyGoSdkUtil.checkDirectoryForTinyGo(it)) it.canonicalPath!!
-            else {
-                Messages.showErrorDialog("Selected TinyGo path is invalid", "Invalid TinyGo")
-                TinyGoSdkUtil.suggestSdkDirectoryStr()
-            }
-        }
-    )
-    private val tinyGoTargetChooser = JBTextField()
-
-    init {
-        tinyGoSdkBrowser.text = TinyGoSdkUtil.suggestSdkDirectoryStr()
+    object TinyGoInfoArgumentsImpl : TinyGoInfoArguments {
+        override var tinyGoSdkPath: String = TinyGoSdkUtil.suggestSdkDirectoryStr()
+        override var tinyGoTarget: String = ""
+        override var tinyGoGarbageCollector: GarbageCollector = GarbageCollector.AUTO_DETECT
+        override var tinyGoScheduler: Scheduler = Scheduler.AUTO_DETECT
     }
+
+    private val propertyGraph = PropertyGraph()
+    var tinyGoSdkPathProp: GraphProperty<String> =
+        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoSdkPath)
+    private var targetProp: GraphProperty<String> =
+        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoTarget)
+    private var gcProp: GraphProperty<GarbageCollector> =
+        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoGarbageCollector)
+    private var schedulerProp: GraphProperty<Scheduler> =
+        propertyGraph.graphProperty(TinyGoInfoArgumentsImpl::tinyGoScheduler)
+
+    private fun decorateSettingsPanelForUI(component: JPanel): JPanel =
+        PanelFactory.grid().add(PanelFactory.panel(component)).resize().createPanel()
 
     override fun createSettingsPanel(
         parentDisposable: Disposable,
         locationComponent: LabeledComponent<TextFieldWithBrowseButton>?,
         sdkCombo: GoSdkChooserCombo?,
         project: Project?
-    ): JPanel = createGridPanel(locationComponent, sdkCombo)
-        .add(PanelFactory.panel(tinyGoSdkBrowser).withLabel("TinyGo path:"))
-        .add(PanelFactory.panel(tinyGoTargetChooser).withLabel("Target board:"))
-        .resize().createPanel()
+    ): JPanel {
+        val panel = JPanel()
+        panel.layout = BoxLayout(panel, BoxLayout.PAGE_AXIS)
+        panel.add(createGridPanel(locationComponent, sdkCombo).resize().createPanel())
+        panel.add(
+            decorateSettingsPanelForUI(
+                TinyGoUIComponents.generateTinyGoParametersPanel(
+                    tinyGoSdkPathProp,
+                    {
+                        if (TinyGoSdkUtil.checkDirectoryForTinyGo(it)) it.canonicalPath!!
+                        else {
+                            Messages.showErrorDialog("Selected TinyGo path is invalid", "Invalid TinyGo")
+                            TinyGoSdkUtil.suggestSdkDirectoryStr()
+                        }
+                    },
+                    targetProp,
+                    gcProp,
+                    schedulerProp,
+                )
+            )
+        )
+        return panel
+    }
 
     override fun getSettings(): TinyGoNewProjectSettings {
-        return TinyGoNewProjectSettings(sdkFromCombo, tinyGoSdkBrowser.text, tinyGoTargetChooser.text)
+        return TinyGoNewProjectSettings(
+            sdk = sdkFromCombo,
+            tinyGoSdkPath = tinyGoSdkPathProp.get(),
+            tinyGoTarget = targetProp.get(),
+            tinyGoGarbageCollector = gcProp.get(),
+            tinyGoScheduler = schedulerProp.get()
+        )
     }
 }

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/sdk/TinyGoSdkUtil.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/sdk/TinyGoSdkUtil.kt
@@ -4,7 +4,6 @@ import com.goide.GoNotifications
 import com.goide.GoOsManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
-import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.ShowSettingsUtil

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/services/TinyGoInfoExtractor.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/services/TinyGoInfoExtractor.kt
@@ -1,8 +1,10 @@
 package org.jetbrains.tinygoplugin.services
 
 import com.goide.util.GoExecutor
+import com.goide.util.GoHistoryProcessListener
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.util.Consumer
 import org.jetbrains.tinygoplugin.configuration.GarbageCollector
 import org.jetbrains.tinygoplugin.configuration.Scheduler
 import org.jetbrains.tinygoplugin.configuration.TinyGoConfiguration
@@ -58,5 +60,14 @@ internal class TinyGoInfoExtractor(private val project: Project) {
             parameters.addAll(listOf("-gc", settings.gc.cmd))
         }
         return parameters
+    }
+
+    fun extractTinyGoInfo(
+        settings: TinyGoConfiguration,
+        processHistory: GoHistoryProcessListener,
+        onFinish: Consumer<in GoExecutor.ExecutionResult?>
+    ) {
+        val executor = assembleTinyGoShellCommand(settings)
+        executor.executeWithProgress(true, true, processHistory, null, onFinish)
     }
 }

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/services/TinyGoSettingsService.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/services/TinyGoSettingsService.kt
@@ -2,83 +2,31 @@ package org.jetbrains.tinygoplugin.services
 
 import com.goide.util.GoHistoryProcessListener
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.observable.properties.GraphProperty
-import com.intellij.openapi.observable.properties.GraphPropertyImpl.Companion.graphProperty
-import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.NamedConfigurable
 import org.jetbrains.tinygoplugin.configuration.TinyGoConfiguration
+import org.jetbrains.tinygoplugin.ui.CanResetSettingsUI
+import org.jetbrains.tinygoplugin.ui.ResetableProperty
+import org.jetbrains.tinygoplugin.ui.TinyGoPropertiesWrapper
 import org.jetbrains.tinygoplugin.ui.TinyGoUIComponents
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
 import javax.swing.JComponent
-import kotlin.reflect.KMutableProperty1
 
-internal interface Resetable {
-    fun reset()
-}
-
-class TinyGoSettingsService(private val project: Project) : NamedConfigurable<TinyGoConfiguration>(), ActionListener {
+class TinyGoSettingsService(private val project: Project) : NamedConfigurable<TinyGoConfiguration>(),
+    CanResetSettingsUI, ActionListener {
     companion object {
         private val logger: Logger = Logger.getInstance(TinyGoSettingsService::class.java)
     }
-    // list of all UI properties to be resetted
-    private val resetableProperties: MutableCollection<Resetable> = ArrayList()
-    // wrapper around graph property that binds the field to the property in settings
-    inner class MappedGraphProperty<T>(
-        private val prop: GraphProperty<T>,
-        private val objProperty: KMutableProperty1<TinyGoConfiguration, T>,
-    ) : GraphProperty<T> by prop, Resetable {
-        init {
-            prop.afterChange {
-                objProperty.set(this@TinyGoSettingsService.settings, it)
-            }
-            prop.afterReset {
-                prop.set(objProperty.get(this@TinyGoSettingsService.settings))
-            }
-            this@TinyGoSettingsService.resetableProperties.add(this)
-        }
-
-        override fun reset() = prop.reset()
-    }
-
-    private val infoExtractor = TinyGoInfoExtractor(project)
 
     // local copy of the settings
-    private var settings = TinyGoConfiguration.getInstance(project).deepCopy()
+    override var settings: TinyGoConfiguration = TinyGoConfiguration.getInstance(project).deepCopy()
 
-    private val propertyGraph = PropertyGraph()
-    // set initial string
-    private val tinygoSDKPath =
-        MappedGraphProperty(
-            prop = propertyGraph.graphProperty(settings::tinyGoSDKPath),
-            objProperty = TinyGoConfiguration::tinyGoSDKPath
-        )
-    private val target = MappedGraphProperty(
-        prop = propertyGraph.graphProperty(settings::targetPlatform),
-        objProperty = TinyGoConfiguration::targetPlatform
-    )
+    // list of all UI properties to be resetted
+    override var resetableProperties: MutableCollection<ResetableProperty> = ArrayList()
 
-    private val gc = MappedGraphProperty(
-        prop = propertyGraph.graphProperty(settings::gc),
-        objProperty = TinyGoConfiguration::gc
-    )
-    private val scheduler = MappedGraphProperty(
-        prop = propertyGraph.graphProperty(settings::scheduler),
-        objProperty = TinyGoConfiguration::scheduler
-    )
-    private val goOS = MappedGraphProperty(
-        prop = propertyGraph.graphProperty(settings::goOS),
-        objProperty = TinyGoConfiguration::goOS
-    )
-    private val goArch = MappedGraphProperty(
-        prop = propertyGraph.graphProperty(settings::goArch),
-        objProperty = TinyGoConfiguration::goArch
-    )
-    private val goTags = MappedGraphProperty(
-        prop = propertyGraph.graphProperty(settings::goTags),
-        objProperty = TinyGoConfiguration::goTags
-    )
+    private val infoExtractor = TinyGoInfoExtractor(project)
+    private val propertiesWrapper = TinyGoPropertiesWrapper(this)
 
     override fun isModified(): Boolean = settings.modified(project)
 
@@ -89,19 +37,24 @@ class TinyGoSettingsService(private val project: Project) : NamedConfigurable<Ti
 
     override fun getDisplayName(): String = "TinyGo"
 
-    override fun actionPerformed(e: ActionEvent?) {
+    private fun callExtractor() {
         val processHistory = GoHistoryProcessListener()
         infoExtractor.extractTinyGoInfo(settings, processHistory) { result ->
             val output = processHistory.output.joinToString("")
             logger.trace(output)
             settings.extractTinyGoInfo(output)
             // update all ui fields
-            goArch.reset()
-            goTags.reset()
-            goOS.reset()
-            gc.reset()
-            scheduler.reset()
+            propertiesWrapper.goArch.reset()
+            propertiesWrapper.goTags.reset()
+            propertiesWrapper.goOS.reset()
+
+            propertiesWrapper.gc.reset()
+            propertiesWrapper.scheduler.reset()
         }
+    }
+
+    override fun actionPerformed(e: ActionEvent?) {
+        callExtractor()
     }
 
     override fun setDisplayName(name: String?) {
@@ -110,7 +63,7 @@ class TinyGoSettingsService(private val project: Project) : NamedConfigurable<Ti
 
     override fun reset() {
         settings = TinyGoConfiguration.getInstance(project).deepCopy()
-        resetableProperties.forEach(Resetable::reset)
+        resetableProperties.forEach(ResetableProperty::reset)
         super.reset()
     }
 
@@ -119,15 +72,9 @@ class TinyGoSettingsService(private val project: Project) : NamedConfigurable<Ti
     override fun getBannerSlogan(): String = "Tinygo slogan"
 
     override fun createOptionsPanel(): JComponent = TinyGoUIComponents.generateSettingsPanel(
-        tinygoSDKPath,
+        propertiesWrapper,
         fileChosen = { it.canonicalPath ?: settings.tinyGoSDKPath },
-        target,
-        gc,
-        scheduler,
         this::actionPerformed,
-        goOS,
-        goArch,
-        goTags,
         project
     )
 }

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/ui/TinyGoPropertiesWrapper.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/ui/TinyGoPropertiesWrapper.kt
@@ -1,0 +1,73 @@
+package org.jetbrains.tinygoplugin.ui
+
+import com.intellij.openapi.observable.properties.GraphProperty
+import com.intellij.openapi.observable.properties.GraphPropertyImpl.Companion.graphProperty
+import com.intellij.openapi.observable.properties.PropertyGraph
+import org.jetbrains.tinygoplugin.configuration.TinyGoConfiguration
+import kotlin.reflect.KMutableProperty1
+
+interface ResetableProperty {
+    fun reset()
+}
+
+interface SettingsDependentUI {
+    var settings: TinyGoConfiguration
+}
+
+interface CanResetSettingsUI : SettingsDependentUI {
+    var resetableProperties: MutableCollection<ResetableProperty>
+}
+
+class TinyGoPropertiesWrapper(val obj: SettingsDependentUI) {
+    // wrapper around graph property that binds the field to the property in settings
+    inner class MappedGraphProperty<T>(
+        private val prop: GraphProperty<T>,
+        private val objProperty: KMutableProperty1<TinyGoConfiguration, T>,
+    ) : GraphProperty<T> by prop, ResetableProperty {
+        init {
+            prop.afterChange {
+                objProperty.set(obj.settings, it)
+            }
+            prop.afterReset {
+                prop.set(objProperty.get(obj.settings))
+            }
+            if (obj is CanResetSettingsUI) {
+                obj.resetableProperties.add(this)
+            }
+        }
+
+        override fun reset() = prop.reset()
+    }
+
+    private val propertyGraph = PropertyGraph()
+    // set initial string
+    val tinygoSDKPath = MappedGraphProperty(
+        prop = propertyGraph.graphProperty(obj.settings::tinyGoSDKPath),
+        objProperty = TinyGoConfiguration::tinyGoSDKPath
+    )
+    val target = MappedGraphProperty(
+        prop = propertyGraph.graphProperty(obj.settings::targetPlatform),
+        objProperty = TinyGoConfiguration::targetPlatform
+    )
+
+    val gc = MappedGraphProperty(
+        prop = propertyGraph.graphProperty(obj.settings::gc),
+        objProperty = TinyGoConfiguration::gc
+    )
+    val scheduler = MappedGraphProperty(
+        prop = propertyGraph.graphProperty(obj.settings::scheduler),
+        objProperty = TinyGoConfiguration::scheduler
+    )
+    val goOS = MappedGraphProperty(
+        prop = propertyGraph.graphProperty(obj.settings::goOS),
+        objProperty = TinyGoConfiguration::goOS
+    )
+    val goArch = MappedGraphProperty(
+        prop = propertyGraph.graphProperty(obj.settings::goArch),
+        objProperty = TinyGoConfiguration::goArch
+    )
+    val goTags = MappedGraphProperty(
+        prop = propertyGraph.graphProperty(obj.settings::goTags),
+        objProperty = TinyGoConfiguration::goTags
+    )
+}

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/ui/TinyGoUIComponents.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/ui/TinyGoUIComponents.kt
@@ -1,0 +1,69 @@
+package org.jetbrains.tinygoplugin.ui
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.observable.properties.GraphProperty
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.EnumComboBoxModel
+import com.intellij.ui.layout.*
+import org.jetbrains.tinygoplugin.configuration.GarbageCollector
+import org.jetbrains.tinygoplugin.configuration.Scheduler
+import java.awt.event.ActionEvent
+import javax.swing.JPanel
+
+class TinyGoUIComponents private constructor() {
+    companion object {
+        fun generateTinyGoParametersPanel(
+            tinyGoSDKPath: GraphProperty<String>,
+            fileChosen: ((chosenFile: VirtualFile) -> String),
+            target: GraphProperty<String>,
+            gc: GraphProperty<GarbageCollector>,
+            scheduler: GraphProperty<Scheduler>,
+            project: Project? = null
+        ): JPanel = panel {
+            row("TinyGo Path") {
+                textFieldWithBrowseButton(
+                    property = tinyGoSDKPath, project = project,
+                    fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor(),
+                    fileChosen = fileChosen
+                )
+            }
+            row("Target platform") {
+                textField(property = target)
+            }
+            row("Compiler parameters:") {
+                comboBox(EnumComboBoxModel(GarbageCollector::class.java), gc)
+                comboBox(EnumComboBoxModel(Scheduler::class.java), scheduler)
+            }
+        }
+
+        fun generateSettingsPanel(
+            tinyGoSDKPath: GraphProperty<String>,
+            fileChosen: ((chosenFile: VirtualFile) -> String),
+            target: GraphProperty<String>,
+            gc: GraphProperty<GarbageCollector>,
+            scheduler: GraphProperty<Scheduler>,
+            actionPerformed: ((event: ActionEvent) -> Unit),
+            goOS: GraphProperty<String>,
+            goArch: GraphProperty<String>,
+            goTags: GraphProperty<String>,
+            project: Project? = null
+        ): JPanel = panel {
+            row {
+                generateTinyGoParametersPanel(tinyGoSDKPath, fileChosen, target, gc, scheduler, project)()
+            }
+            row {
+                button("Detect", actionPerformed)
+            }
+            row("GOOS") {
+                textField(property = goOS).enabled(false)
+            }
+            row("GOARCH") {
+                textField(property = goArch).enabled(false)
+            }
+            row("Go tags") {
+                textField(property = goTags).enabled(false)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/tinygoplugin/ui/TinyGoUIComponents.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/ui/TinyGoUIComponents.kt
@@ -1,11 +1,10 @@
 package org.jetbrains.tinygoplugin.ui
 
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
-import com.intellij.openapi.observable.properties.GraphProperty
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.EnumComboBoxModel
-import com.intellij.ui.layout.*
+import com.intellij.ui.layout.panel
 import org.jetbrains.tinygoplugin.configuration.GarbageCollector
 import org.jetbrains.tinygoplugin.configuration.Scheduler
 import java.awt.event.ActionEvent
@@ -14,55 +13,46 @@ import javax.swing.JPanel
 class TinyGoUIComponents private constructor() {
     companion object {
         fun generateTinyGoParametersPanel(
-            tinyGoSDKPath: GraphProperty<String>,
+            wrapper: TinyGoPropertiesWrapper,
             fileChosen: ((chosenFile: VirtualFile) -> String),
-            target: GraphProperty<String>,
-            gc: GraphProperty<GarbageCollector>,
-            scheduler: GraphProperty<Scheduler>,
             project: Project? = null
         ): JPanel = panel {
             row("TinyGo Path") {
                 textFieldWithBrowseButton(
-                    property = tinyGoSDKPath, project = project,
+                    property = wrapper.tinygoSDKPath, project = project,
                     fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor(),
                     fileChosen = fileChosen
                 )
             }
             row("Target platform") {
-                textField(property = target)
+                textField(property = wrapper.target)
             }
             row("Compiler parameters:") {
-                comboBox(EnumComboBoxModel(GarbageCollector::class.java), gc)
-                comboBox(EnumComboBoxModel(Scheduler::class.java), scheduler)
+                comboBox(EnumComboBoxModel(GarbageCollector::class.java), wrapper.gc)
+                comboBox(EnumComboBoxModel(Scheduler::class.java), wrapper.scheduler)
             }
         }
 
         fun generateSettingsPanel(
-            tinyGoSDKPath: GraphProperty<String>,
+            wrapper: TinyGoPropertiesWrapper,
             fileChosen: ((chosenFile: VirtualFile) -> String),
-            target: GraphProperty<String>,
-            gc: GraphProperty<GarbageCollector>,
-            scheduler: GraphProperty<Scheduler>,
             actionPerformed: ((event: ActionEvent) -> Unit),
-            goOS: GraphProperty<String>,
-            goArch: GraphProperty<String>,
-            goTags: GraphProperty<String>,
             project: Project? = null
         ): JPanel = panel {
             row {
-                generateTinyGoParametersPanel(tinyGoSDKPath, fileChosen, target, gc, scheduler, project)()
+                generateTinyGoParametersPanel(wrapper, fileChosen, project)()
             }
             row {
                 button("Detect", actionPerformed)
             }
             row("GOOS") {
-                textField(property = goOS).enabled(false)
+                textField(property = wrapper.goOS).enabled(false)
             }
             row("GOARCH") {
-                textField(property = goArch).enabled(false)
+                textField(property = wrapper.goArch).enabled(false)
             }
             row("Go tags") {
-                textField(property = goTags).enabled(false)
+                textField(property = wrapper.goTags).enabled(false)
             }
         }
     }


### PR DESCRIPTION
- Moved settings UI panels generation into separate static util class
- MappedGraphProperty<T> and its objects moved from TinyGoSettingsService to separate class
- Unified API to use settings panels in different scopes (settings and project wizard now)
- TinyGo basic configuration in project wizard