### PR TITLE
Add `cores` scheduler

### DIFF
--- a/src/main/kotlin/org/jetbrains/tinygoplugin/configuration/Fields.kt
+++ b/src/main/kotlin/org/jetbrains/tinygoplugin/configuration/Fields.kt
@@ -14,6 +14,7 @@ enum class Scheduler(val cmd: String) {
     AUTO_DETECT("auto"),
     NONE("none"),
     ASYNCIFY("asyncify"),
+    CORES("cores"),
     TASKS("tasks");
 
     override fun toString(): String = cmd


### PR DESCRIPTION
Add support for [the new `cores` scheduler](https://github.com/tinygo-org/tinygo/releases/tag/v0.38.0).

Resolves: https://youtrack.jetbrains.com/issue/GO-19110/TinyGo-Support-cores-scheduler