### PR TITLE
Add GoLand 2026.2 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,27 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v2
 
-      # Setup Java environment for the next steps
-      - name: Setup Java
+      # Setup Java 25 for the IntelliJ Platform toolchain
+      - name: Setup Java 25
+        uses: actions/setup-java@v4.2.2
+        with:
+          distribution: zulu
+          java-version: 25
+
+      - name: Save Java 25 path
+        shell: bash
+        run: echo "JAVA_25_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      # Keep Gradle and legacy analysis tools on Java 21
+      - name: Setup Java 21
         uses: actions/setup-java@v4.2.2
         with:
           distribution: zulu
           java-version: 21
+
+      - name: Configure Java toolchain
+        shell: bash
+        run: echo "GRADLE_OPTS=-Dorg.gradle.java.installations.paths=$JAVA_25_HOME" >> "$GITHUB_ENV"
 
       # Setup Gradle
       - name: Setup Gradle
@@ -110,12 +125,27 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
-      # Setup Java environment for the next steps
-      - name: Setup Java
+      # Setup Java 25 for the IntelliJ Platform toolchain
+      - name: Setup Java 25
+        uses: actions/setup-java@v4.2.2
+        with:
+          distribution: zulu
+          java-version: 25
+
+      - name: Save Java 25 path
+        shell: bash
+        run: echo "JAVA_25_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      # Keep Gradle and legacy analysis tools on Java 21
+      - name: Setup Java 21
         uses: actions/setup-java@v4.2.2
         with:
           distribution: zulu
           java-version: 21
+
+      - name: Configure Java toolchain
+        shell: bash
+        run: echo "GRADLE_OPTS=-Dorg.gradle.java.installations.paths=$JAVA_25_HOME" >> "$GITHUB_ENV"
 
       # Setup Gradle
       - name: Setup Gradle
@@ -144,12 +174,27 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
-      # Setup Java environment for the next steps
-      - name: Setup Java
+      # Setup Java 25 for the IntelliJ Platform toolchain
+      - name: Setup Java 25
+        uses: actions/setup-java@v4.2.2
+        with:
+          distribution: zulu
+          java-version: 25
+
+      - name: Save Java 25 path
+        shell: bash
+        run: echo "JAVA_25_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      # Keep Gradle and legacy analysis tools on Java 21
+      - name: Setup Java 21
         uses: actions/setup-java@v4.2.2
         with:
           distribution: zulu
           java-version: 21
+
+      - name: Configure Java toolchain
+        shell: bash
+        run: echo "GRADLE_OPTS=-Dorg.gradle.java.installations.paths=$JAVA_25_HOME" >> "$GITHUB_ENV"
 
       # Setup Gradle
       - name: Setup Gradle
@@ -189,12 +234,27 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
-      # Setup Java environment for the next steps
-      - name: Setup Java
+      # Setup Java 25 for the IntelliJ Platform toolchain
+      - name: Setup Java 25
+        uses: actions/setup-java@v4.2.2
+        with:
+          distribution: zulu
+          java-version: 25
+
+      - name: Save Java 25 path
+        shell: bash
+        run: echo "JAVA_25_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      # Keep Gradle and legacy analysis tools on Java 21
+      - name: Setup Java 21
         uses: actions/setup-java@v4.2.2
         with:
           distribution: zulu
           java-version: 21
+
+      - name: Configure Java toolchain
+        shell: bash
+        run: echo "GRADLE_OPTS=-Dorg.gradle.java.installations.paths=$JAVA_25_HOME" >> "$GITHUB_ENV"
 
       # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,27 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      # Setup Java environment for the next steps
-      - name: Setup Java
+      # Setup Java 25 for the IntelliJ Platform toolchain
+      - name: Setup Java 25
+        uses: actions/setup-java@v4.2.2
+        with:
+          distribution: zulu
+          java-version: 25
+
+      - name: Save Java 25 path
+        shell: bash
+        run: echo "JAVA_25_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      # Keep Gradle and legacy analysis tools on Java 21
+      - name: Setup Java 21
         uses: actions/setup-java@v4.2.2
         with:
           distribution: zulu
           java-version: 21
+
+      - name: Configure Java toolchain
+        shell: bash
+        run: echo "GRADLE_OPTS=-Dorg.gradle.java.installations.paths=$JAVA_25_HOME" >> "$GITHUB_ENV"
 
       # Setup Gradle
       - name: Setup Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,9 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    id("org.jetbrains.kotlin.jvm") version "2.4.0"
     // IntelliJ Platform Gradle Plugin
-    id("org.jetbrains.intellij.platform") version "2.3.0"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "2.2.1"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
@@ -28,12 +28,12 @@ version = properties("pluginVersion").get()
 
 // Set the JVM language level used to build the project.
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 
@@ -52,7 +52,7 @@ repositories {
 dependencies {
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
-        goland(properties("platformVersion"), useInstaller = false)
+        goland(properties("platformVersion"))
         jetbrainsRuntime()
 
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
@@ -65,7 +65,7 @@ dependencies {
         bundledModules(properties("platformBundledModules").map { it.split(',') })
 
         testFramework(TestFrameworkType.Platform)
-        testFramework(TestFrameworkType.Plugin.Go, "GOLAND-261-EAP-SNAPSHOT")
+        testFramework(TestFrameworkType.Plugin.Go)
     }
 
     testImplementation(kotlin("test"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,14 +5,14 @@ pluginGroup = org.jetbrains.tinygoplugin
 pluginName = tinygo-plugin
 pluginRepositoryUrl = https://github.com/JetBrains/tinygo-plugin
 pluginVersion = 0.5.22
-pluginSinceBuild = 261.17801.55
-pluginUntilBuild = 261.*
+pluginSinceBuild = 262.8665.336
+pluginUntilBuild = 262.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = IU-2026.1
+pluginVerifierIdeVersions = IU-2026.2
 
 platformType = GO
-platformVersion = 261-EAP-SNAPSHOT
+platformVersion = 2026.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
@@ -21,10 +21,10 @@ platformPlugins = com.intellij.modules.json:243.23654.117
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = org.jetbrains.plugins.go
 # Example: platformBundledModules = intellij.spellchecker
-platformBundledModules = intellij.platform.langInjection
+platformBundledModules = intellij.platform.langInjection,intellij.platform.ui.jcef
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.5
+gradleVersion = 9.6.1
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

- Add compatibility with GoLand 2026.2 (`262.*`), starting at build `262.8665.336`.
- Update the IntelliJ Platform Gradle Plugin, Gradle, Kotlin, and Java toolchain for the 2026.2 platform.
- Add the JCEF bundled module and update CI/release workflows to provide Java 21 for legacy analysis tools and Java 25 for compilation.

## Verification

- `./gradlew check` — passed with Gradle running on JDK 21 and JDK 25 configured as the Java toolchain.
- `./gradlew buildPlugin` — passed.
- `actionlint .github/workflows/build.yml .github/workflows/release.yml` — passed.
